### PR TITLE
pin version of sphinxcontrib-bibtex<2.0.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,8 +22,6 @@ before_script:
   - source venv/bin/activate
 
 pages:
-  tags:
-    - GWDG-Runner-2
   script:
     - pip install -r requirements.txt
     - jupyter-book build how_to_eurec4a
@@ -35,8 +33,6 @@ pages:
     - master
 
 testbuild:
-  tags:
-    - GWDG-Runner-2
   script:
     - pip install -r requirements.txt
     - jupyter-book build how_to_eurec4a

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ ipfsspec
 requests
 aiohttp
 pydap
+sphinxcontrib-bibtex<2.0.0


### PR DESCRIPTION
The root cause of previous build failures seems to be related to an
incompatible upgrade of the `sphinxcontrib-bibtex` package as also noted
in executablebooks/jupyter-book#1137. This pin can most likely be
removed once a new version of `jupyter-book` is available, either
because `jupyter-book` includes the pin in its dependencies or because it
adapts to the new requirements of `sphinxcontrib-bibtex`.

I've also removed the tag for the gitlab runner as it is very likely
that it was working on the one runner and not on the other because it
cached an older version of `sphinxcontrib-bibtex` and as soon as the
cache would be emptied the issue might arise again.