### PR TITLE
upgrade ipfsspec to >= 0.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ eurec4a
 intake
 intake-xarray
 fsspec
-ipfsspec
+ipfsspec>=0.0.2
 requests
 aiohttp
 pydap


### PR DESCRIPTION
That ipfsspec release adds request slow down in case a gateway server
asks for slower requests (i.e. HTTP 429).