### PR TITLE
requirements: changed intake -> intake[dataframe]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ matplotlib
 numpy
 xarray
 eurec4a
-intake
+intake[dataframe] # since intake 0.6.1 to_dask() doesn't work anymore without the [dataframe] specification due to a missing msgpack dependency
 intake-xarray
 fsspec
 ipfsspec>=0.0.2


### PR DESCRIPTION
Since intake v0.6.1 which has just been released, the `to_dask()` function does not work anymore without requiring the `[dataframe]` section of the `intake` package. This change should fix the issue with currently failing builds.